### PR TITLE
Moves title initialization to init so clients can change the property

### DIFF
--- a/CTAssetsPickerController/CTAssetsPickerController.m
+++ b/CTAssetsPickerController/CTAssetsPickerController.m
@@ -171,6 +171,8 @@
 {
     if (self = [super initWithStyle:UITableViewStylePlain])
     {
+        self.title = @"Photos";
+        
         if ([self respondsToSelector:@selector(setContentSizeForViewInPopover:)])
             [self setContentSizeForViewInPopover:kPopoverContentSize];
     }
@@ -225,7 +227,7 @@
 
 - (void)localize
 {
-    self.title = NSLocalizedString(@"Photos", nil);
+    self.title = NSLocalizedString(self.title, nil);
 }
 
 - (void)setupGroup


### PR DESCRIPTION
This PR makes it possible to change the title on the root view controller.  In our case, we'd like it to read "Videos" instead of "Photos" since we limit the collection to only videos and no photos.

`setTitle:` can be called after `init` but before `viewDidLoad` calls `localize`
