### PR TITLE
Update CTAssetsGroupViewController.m

### DIFF
--- a/CTAssetsPickerController/CTAssetsGroupViewController.m
+++ b/CTAssetsPickerController/CTAssetsGroupViewController.m
@@ -172,7 +172,7 @@
             else
                 shouldShowGroup = YES;
             
-            if (shouldShowGroup)
+            if (shouldShowGroup && ([group numberOfAssets] > 0))
                 [self.groups addObject:group];
         }
         else


### PR DESCRIPTION
This is to ensure that only groups/folders are shown if they have valid assets. (ie applied AllVideos filter and groups contain only photos, that group should not be displayed)
