### PR TITLE
Extracted Navigation Controller creation to a separate method.

### DIFF
--- a/CTAssetsPickerController/CTAssetsPickerController.m
+++ b/CTAssetsPickerController/CTAssetsPickerController.m
@@ -72,7 +72,7 @@ NSString * const CTAssetsPickerSelectedAssetsChangedNotification = @"CTAssetsPic
 - (void)setupNavigationController
 {
     CTAssetsGroupViewController *vc = [[CTAssetsGroupViewController alloc] init];
-    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
+    UINavigationController *nav = [[self createNavigationController] initWithRootViewController:vc];
     nav.delegate = self;
     
     [nav willMoveToParentViewController:self];
@@ -82,7 +82,10 @@ NSString * const CTAssetsPickerSelectedAssetsChangedNotification = @"CTAssetsPic
     [nav didMoveToParentViewController:self];
 }
 
-
+- (UINavigationController *)createNavigationController
+{
+    return [UINavigationController alloc];
+}
 
 #pragma mark - UINavigationControllerDelegate
 


### PR DESCRIPTION
For most customization needs, accessing the `navigationController` property of the assets picker will be sufficient. But you may need to specify a custom UINavigationController subclass if you want to control things like the status bar:

``` objective-c
- (UIStatusBarStyle)preferredStatusBarStyle
{
    return UIStatusBarStyleLightContent;
}
```

Or maybe you already have a `BaseNavigationController` you would prefer to use instead of the stock one.

This Pull Request adds a `-createNavigationController` method that can be easily overridden to return your custom Navigation Controller subclass:

``` objective-c
@interface BaseAssetsPickerController : CTAssetsPickerController 
@end

@implementation BaseAssetsPickerController
- (UINavigationController *)createNavigationController
{
    return [BaseNavigationController alloc];
}
@end
```
