### PR TITLE
Now supports customized footer text attributes.

### DIFF
--- a/CTAssetsPickerController/CTAssetsPickerController.h
+++ b/CTAssetsPickerController/CTAssetsPickerController.h
@@ -90,6 +90,13 @@
  */
 @property (nonatomic, readonly, strong) UINavigationController *childNavigationController;
 
+/**
+ *  The default toolbar text attributes.
+ *
+ *  The default color is black.  You can set this to nil, to have the toolbar use the global
+ *  appearance's text attributes, or you can set them here.
+ */
+@property (nonatomic, copy, readwrite) NSDictionary *defaultToolbarTextAttributes;
 
 /**
  *  @name Managing Selections

--- a/CTAssetsPickerController/CTAssetsPickerController.m
+++ b/CTAssetsPickerController/CTAssetsPickerController.m
@@ -47,6 +47,7 @@ NSString * const CTAssetsPickerSelectedAssetsChangedNotification = @"CTAssetsPic
     {
         _assetsLibrary          = [self.class defaultAssetsLibrary];
         _assetsFilter           = [ALAssetsFilter allAssets];
+        _defaultToolbarTextAttributes = @{NSForegroundColorAttributeName : [UIColor blackColor]};
         _selectedAssets         = [[NSMutableArray alloc] init];
         _showsCancelButton      = YES;
         _showsNumberOfAssets    = YES;
@@ -420,7 +421,6 @@ NSString * const CTAssetsPickerSelectedAssetsChangedNotification = @"CTAssetsPic
     return [NSString stringWithFormat:format, (long)self.selectedAssets.count];
 }
 
-
 #pragma mark - Toolbar Items
 
 - (UIBarButtonItem *)titleButtonItem
@@ -431,10 +431,13 @@ NSString * const CTAssetsPickerSelectedAssetsChangedNotification = @"CTAssetsPic
                                     target:nil
                                     action:nil];
     
-    NSDictionary *attributes = @{NSForegroundColorAttributeName : [UIColor blackColor]};
+    if (self.defaultToolbarTextAttributes) {
+        [title setTitleTextAttributes:self.defaultToolbarTextAttributes
+                             forState:UIControlStateNormal];
+        [title setTitleTextAttributes:self.defaultToolbarTextAttributes
+                             forState:UIControlStateDisabled];
+    }
     
-    [title setTitleTextAttributes:attributes forState:UIControlStateNormal];
-    [title setTitleTextAttributes:attributes forState:UIControlStateDisabled];
     [title setEnabled:NO];
     
     return title;


### PR DESCRIPTION
This fix allows for the customization of the footer's `UIBarButtonItem` global-appearance text attributes without `CTAssetPickerController` overriding it.

For example:

``` objective-c
[[UIBarButtonItem appearance] setTitleTextAttributes:@{NSFontAttributeName:[UIFont systemFontOfSize:10], NSForegroundColorAttributeName: [UIColor whiteColor]} forState:UIControlStateNormal];
```

Another alternative to this fix could be to remove from `CTAssetsPickerController.m` the code that sets the footer's `UIBarButtonItem` text attributes.
