### PR TITLE
Fix bug when assets group changed, the asset filter is not re-applied

### DIFF
--- a/CTAssetsPickerController/CTAssetsGroupViewController.m
+++ b/CTAssetsPickerController/CTAssetsGroupViewController.m
@@ -290,7 +290,10 @@
         if (index != NSNotFound)
         {
             NSIndexPath *indexPath = [NSIndexPath indexPathForRow:index inSection:0];
-            
+
+            /* Re-apply the filter if the group changed */
+            [group setAssetsFilter:self.picker.assetsFilter];
+
             [self.groups replaceObjectAtIndex:index withObject:group];
             [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
         }
@@ -306,6 +309,9 @@
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:self.groups.count inSection:0];
         
         [self.tableView beginUpdates];
+        
+        /* Re-apply the filter for inserted group */
+        [group setAssetsFilter:self.picker.assetsFilter];
         
         [self.groups addObject:group];
         [self.tableView insertRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];


### PR DESCRIPTION
If I set the assets filter to be all photos, I can open the picker and see all photos shown. If I go to the Photos app and make some changes (like delete a photo), when I come back to the picker, I can see the collection reloaded with the photo removed. However, this time I will also see videos as well. 

This is because the asset groups are also reloaded on ALAssetsLibraryChangedNotification but the assets filter is not re-applied in updateAssetsGroupForURL: and insertAssetsGroupForURL: