### PR TITLE
Better Japanese translation of "Done"

### DIFF
--- a/CTAssetsPickerController/ja.lproj/CTAssetsPickerController.strings
+++ b/CTAssetsPickerController/ja.lproj/CTAssetsPickerController.strings
@@ -1,6 +1,6 @@
 /* Navigation bar buttons */
 "Cancel" = "キャンセル";
-"Done" = "終了";
+"Done" = "完了";
 
 /* Default title */
 "Photos" = "写真";


### PR DESCRIPTION
If we use "終了", it's not clear if we finish picking up images or canceling it. I believe "完了" is much better. For example, iOS Fcebook app use the word.