### PR TITLE
Add Finnish language support

### DIFF
--- a/CTAssetsPickerDemo.xcodeproj/project.pbxproj
+++ b/CTAssetsPickerDemo.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		37AB9ED3927E2C7F99667B50 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		453FEBD9917867C79B853164 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		78FC009B0D59C0E3BB69A7DE /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		79B51BE71A97741A0015DD2D /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/CTAssetsPickerController.strings; sourceTree = "<group>"; };
 		AD309FC619E67B7500BFCE8B /* CTAssetsPickerCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTAssetsPickerCommon.h; sourceTree = "<group>"; };
 		AD58798218E54F0C00B5773D /* CTAssetsGroupViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTAssetsGroupViewController.h; sourceTree = "<group>"; };
 		AD58798318E54F0C00B5773D /* CTAssetsGroupViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CTAssetsGroupViewController.m; sourceTree = "<group>"; };
@@ -306,6 +307,7 @@
 				he,
 				id,
 				"hi-IN",
+				fi,
 			);
 			mainGroup = ADE31D7D17EFF08C008958B8;
 			productRefGroup = ADE31D8717EFF08C008958B8 /* Products */;
@@ -411,6 +413,7 @@
 				249481B31A4F3689000827AC /* de */,
 				249481B41A4F368C000827AC /* zh-Hant */,
 				249481B51A4F368F000827AC /* en */,
+				79B51BE71A97741A0015DD2D /* fi */,
 			);
 			name = CTAssetsPickerController.strings;
 			sourceTree = "<group>";

--- a/Resources/fi.lproj/CTAssetsPickerController.strings
+++ b/Resources/fi.lproj/CTAssetsPickerController.strings
@@ -1,0 +1,48 @@
+/* Navigation bar buttons */
+"Cancel" = "Kumoa";
+"Done" = "Valmis";
+
+/* Default title */
+"Photos" = "Kuvat";
+
+/* No. of selected */
+"%ld Photo Selected" = "%ld kuva valittu";
+"%ld Photos Selected" = "%ld kuvaa valittu";
+"%ld Video Selected" = "%ld video valittu";
+"%ld Videos Selected" = "%ld videota valittu";
+"%ld Items Selected" = "%ld kohdetta valittu";
+
+/* Album's footer */
+"%ld Photos" = "%ld kuvaa";
+"%ld Videos" = "%ld videota";
+"%ld Photos, %ld Videos" = "%1$ld kuvaa, %2$ld videota";
+
+/* Assets index */
+"%ld of %ld" = "%1$ld / %2$ld";
+
+/* Messages if privacy is not granted */
+"This app does not have access to your photos or videos." = "Sovelluksella ei ole pääsyä kuviin tai videoihin.";
+"You can enable access in Privacy Settings." = "Voit sallia pääsyn Asetukset-valikossa.";
+
+/* Messages if no assets */
+"No Photos or Videos" = "Ei kuvia tai videoita";
+
+/* The parameter will be replaced by the device model name */
+"You can take photos and videos using the camera, or sync photos and videos onto your %@\nusing iTunes." = "Voit ottaa kuvia ja videokuvata kameralla tai synkroinoida iTunesin avulla kuvia ja videoita %@en.";
+"You can sync photos and videos onto your %@ using iTunes." = "Voit synkroinoida iTunesin avulla kuvia ja videoita %@en.";
+
+/* Accessibility labels */
+"Photo" = "Kuva";
+"Video" = "Video";
+"Portrait" = "Pystytila";
+"Landscape" = "Vaakatila";
+"Play" = "Toista";
+"Not available" = "Ei saatavilla";
+
+/* Video duration spell out */
+"hours" = "tuntia";
+"hour" = "tunti";
+"minutes" = "minuuttia";
+"minute" = "minuutti";
+"seconds" = "sekuntia";
+"second" = "sekunti";


### PR DESCRIPTION
During development work with CTAssetsPickerController, we noticed that currently this controller doesn't support Finnish language. So we decided to contribute this project, and created new language support for Finnish. We carefully translated these words into Finnish by our Finnish developer, and we hope that this will be helpful for many Finnish speaking developers.