### PR TITLE
Remove deprication warrnings for iOS 8

### DIFF
--- a/CTAssetsPickerController/CTAssetsViewController.m
+++ b/CTAssetsPickerController/CTAssetsViewController.m
@@ -70,7 +70,8 @@ NSString * const CTAssetsSupplementaryViewIdentifier = @"CTAssetsSupplementaryVi
 
 - (id)init
 {
-    UICollectionViewFlowLayout *layout = [self collectionViewFlowLayoutOfOrientation:self.interfaceOrientation];
+    UIInterfaceOrientation interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
+    UICollectionViewFlowLayout *layout = [self collectionViewFlowLayoutOfOrientation:interfaceOrientation];
     
     if (self = [super initWithCollectionViewLayout:layout])
     {

--- a/CTAssetsPickerController/NSDateFormatter+timeIntervalFormatter.m
+++ b/CTAssetsPickerController/NSDateFormatter+timeIntervalFormatter.m
@@ -82,8 +82,8 @@
     NSDate *date2 = [[NSDate alloc] initWithTimeInterval:timeInterval sinceDate:date1];
     
     unsigned int unitFlags =
-    NSSecondCalendarUnit | NSMinuteCalendarUnit | NSHourCalendarUnit |
-    NSDayCalendarUnit | NSMonthCalendarUnit | NSYearCalendarUnit;
+    NSCalendarUnitSecond | NSCalendarUnitMinute | NSCalendarUnitHour |
+    NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear;
     
     return [calendar components:unitFlags
                        fromDate:date1


### PR DESCRIPTION
iOS 8 depricated `interfaceOrientation` property of `UIViewController`.

`CTAssetsViewController` was using `interfaceOrientation` and documentation
suggests using `[[UIApplication sharedApplication] statusBarOrientation]`
instead, so I've replaced it.

Definitions on `NSCalendarUnit` enum were renamed, and old names were
depricated. I've replaced old names with new.