### PR TITLE
Let delegate control stuff

### DIFF
--- a/CTAssetsPickerController/CTAssetsPickerController.m
+++ b/CTAssetsPickerController/CTAssetsPickerController.m
@@ -481,10 +481,11 @@ NSString * const CTAssetsPickerSelectedAssetsChangedNotification = @"CTAssetsPic
 
 - (void)dismiss:(id)sender
 {
-    if ([self.delegate respondsToSelector:@selector(assetsPickerControllerDidCancel:)])
+    if ([self.delegate respondsToSelector:@selector(assetsPickerControllerDidCancel:)]) {
         [self.delegate assetsPickerControllerDidCancel:self];
-    
-    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+    } else {
+        [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+    }
 }
 
 


### PR DESCRIPTION
Hi @chiunam

Love your work a lot, until I found this design may cause some weird bugs.

## What Did I change? 
no `dismissViewControllerAnimated:completion:` call in `-dismiss` when `-assetsPickerControllerDidCancel` is implemented

## Why?
1. If you don't implement `imagePickerControllerDidCancel:`, UIImagePickerController just does't do anything. So, I hope CTAssetsPickerController could stay consistent.
2. User may want to use other method to dismiss your picker. (Like if I add the view directly to somewhere as a subview, then I want to dismiss it by removing it from super view. That's extremely bad practice though.)
3. Lost control of completion block of dismissing.

I just deleted the `dismissViewControllerAnimated:completion:` at first, then I think if user doesn't implement `-assetsPickerControllerDidCancel`, it should stay what it behaves as you designed, so I put it in an `else`.

Hope you agree with my thoughts. :D