### PR TITLE
Fixed issue on iPad in portrait mode / minor fix of German translation

### DIFF
--- a/CTAssetsPickerController/CTAssetsPickerController.m
+++ b/CTAssetsPickerController/CTAssetsPickerController.m
@@ -245,6 +245,7 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
     
     svc.delegate = self;
     svc.presentsWithGesture = NO;
+    svc.preferredDisplayMode =  UISplitViewControllerDisplayModeAllVisible;
     
     [svc willMoveToParentViewController:self];
     [svc setViewControllers:@[master, detail]];

--- a/CTAssetsPickerController/Resources/de.lproj/CTAssetsPicker.strings
+++ b/CTAssetsPickerController/Resources/de.lproj/CTAssetsPicker.strings
@@ -25,7 +25,7 @@
 "You can enable access in Privacy Settings." = "Sie können den Zugriff in den Datenschutz Einstellungen erlauben.";
 
 /* Messages if no assets */
-"No Photos or Videos" = "Keine Fotos oder Videos ausgewählt";
+"No Photos or Videos" = "Keine Fotos oder Videos vorhanden";
 
 /* The parameter will be replaced by the device model name */
 "You can take photos and videos using the camera, or sync photos and videos onto your %@\nusing iTunes." = "Sie können Fotos oder Videos mit der Kamera aufnehmen oder Ihr %@\nmit iTunes synchronisieren.";

--- a/CTAssetsPickerController/Resources/de.lproj/CTAssetsPicker.strings
+++ b/CTAssetsPickerController/Resources/de.lproj/CTAssetsPicker.strings
@@ -22,7 +22,7 @@
 
 /* Messages if privacy is not granted */
 "This app does not have access to your photos or videos." = "Diese App darf nicht auf Ihr Fotoalbum zugreifen.";
-"You can enable access in Privacy Settings." = "Sie können den Zugriff in den Einstellungen erlauben.";
+"You can enable access in Privacy Settings." = "Sie können den Zugriff in den Datenschutz Einstellungen erlauben.";
 
 /* Messages if no assets */
 "No Photos or Videos" = "Keine Fotos oder Videos ausgewählt";


### PR DESCRIPTION
Hi,

commit 0d929ac fixes an issue on iPad. When using in portrait mode only a white screen is shown. This is simply because UISplitViewController will not show the primary view controller when in portrait mode on iPad. I changed the preferredDisplayMode in order to show primary and secondary view controllers. This should work for all use cases of CTAssetsPickerController.
It will also fix issue #134 

The second commit is a minor improvement for the german translation.

Best regards
Urs