### PR TITLE
Fixed assets not being displayed

### DIFF
--- a/CTAssetsPickerController/CTAssetsPickerController.m
+++ b/CTAssetsPickerController/CTAssetsPickerController.m
@@ -171,7 +171,7 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
         case PHAuthorizationStatusAuthorized:
         default:
         {
-            [self checkAssetsCount];
+            [self showAssetCollectionViewController];
             break;
         }
     }
@@ -187,7 +187,7 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
             case PHAuthorizationStatusAuthorized:
             {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    [self checkAssetsCount];
+                    [self showAssetCollectionViewController];
                 });
                 break;
             }
@@ -201,21 +201,6 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
         }
     }];
 }
-
-
-#pragma mark - Check assets count
-
-- (void)checkAssetsCount
-{
-    PHFetchResult *fetchResult = [PHAsset fetchAssetsWithOptions:self.assetsFetchOptions];
-    
-    if (fetchResult.count > 0) {
-        [self showAssetCollectionViewController];
-    } else {
-        [self showNoAssets];
-    }
-}
-
 
 #pragma mark - Setup views
 


### PR DESCRIPTION
Do not check assets count in CTAssetsPickerController but directly call showAssetCollectionViewController:

- the simple check that checkAssetsCount made did not deliver the same results
- CTAssetCollectionViewController already properly handles if there are no assets available

This is an issue for example when the camera roll is empty put the user manually adds images/albums via iTunes. 