### PR TITLE
Customize Done button title

### DIFF
--- a/CTAssetsPickerController/CTAssetCollectionViewController.h
+++ b/CTAssetsPickerController/CTAssetCollectionViewController.h
@@ -28,6 +28,7 @@
 
 @interface CTAssetCollectionViewController : UITableViewController
 
+- (void)updateButton:(NSArray *)selectedAssets;
 - (void)reloadUserInterface;
 
 @end

--- a/CTAssetsPickerController/CTAssetCollectionViewController.m
+++ b/CTAssetsPickerController/CTAssetCollectionViewController.m
@@ -158,7 +158,7 @@
                                     action:@selector(dismiss:)];
 
     self.doneButton =
-    [[UIBarButtonItem alloc] initWithTitle:CTAssetsPickerLocalizedString(@"Done", nil)
+    [[UIBarButtonItem alloc] initWithTitle:self.picker.doneButtonTitle
                                      style:UIBarButtonItemStyleDone
                                     target:self.picker
                                     action:@selector(finishPickingAssets:)];
@@ -327,6 +327,14 @@
 
 - (void)updateButton:(NSArray *)selectedAssets
 {
+	NSString* doneButtonTitle = self.picker.doneButtonTitle ? self.picker.doneButtonTitle : @"";
+	NSString* currentTitle = self.doneButton.title;
+	
+	if (![currentTitle isEqualToString:doneButtonTitle])
+	{
+		self.doneButton.title = doneButtonTitle;
+	}
+	
     self.navigationItem.leftBarButtonItem = (self.picker.showsCancelButton) ? self.cancelButton : nil;
     self.navigationItem.rightBarButtonItem = [self isTopViewController] ? self.doneButton : nil;
     

--- a/CTAssetsPickerController/CTAssetsGridViewController.h
+++ b/CTAssetsPickerController/CTAssetsGridViewController.h
@@ -45,6 +45,8 @@
 @property (nonatomic, weak) id<CTAssetsGridViewControllerDelegate> delegate;
 @property (nonatomic, strong) PHAssetCollection *assetCollection;
 
+- (void)updateButton:(NSArray *)selectedAssets;
+
 @end
 
 

--- a/CTAssetsPickerController/CTAssetsGridViewController.m
+++ b/CTAssetsPickerController/CTAssetsGridViewController.m
@@ -168,13 +168,17 @@ NSString * const CTAssetsGridViewFooterIdentifier = @"CTAssetsGridViewFooterIden
     self.collectionView.backgroundColor = [UIColor whiteColor];
 }
 
+- (UIBarButtonItem*)createDoneButton
+{
+	return [[UIBarButtonItem alloc] initWithTitle:self.picker.doneButtonTitle
+												style:UIBarButtonItemStyleDone
+											   target:self.picker
+											   action:@selector(finishPickingAssets:)];
+}
+
 - (void)setupButtons
 {
-    self.navigationItem.rightBarButtonItem =
-    [[UIBarButtonItem alloc] initWithTitle:CTAssetsPickerLocalizedString(@"Done", nil)
-                                     style:UIBarButtonItemStyleDone
-                                    target:self.picker
-                                    action:@selector(finishPickingAssets:)];
+	self.navigationItem.rightBarButtonItem = [self createDoneButton];
 }
 
 - (void)setupAssets
@@ -359,6 +363,17 @@ NSString * const CTAssetsGridViewFooterIdentifier = @"CTAssetsGridViewFooterIden
 
 - (void)updateButton:(NSArray *)selectedAssets
 {
+	NSString* doneButtonTitle = self.picker.doneButtonTitle ? self.picker.doneButtonTitle : @"";
+	NSString* currentTitle = self.navigationItem.rightBarButtonItem.title;
+	
+	if (![currentTitle isEqualToString:doneButtonTitle])
+	{
+		// If we just update title, when title is wider than the previous one,
+		// there's this strange animation effect: ellipsis and then actual title.
+		// So re-create item rather than update its title.
+		[self.navigationItem setRightBarButtonItem:[self createDoneButton] animated:YES];
+	}
+	
     if (self.picker.alwaysEnableDoneButton)
         self.navigationItem.rightBarButtonItem.enabled = YES;
     else

--- a/CTAssetsPickerController/CTAssetsPickerController.h
+++ b/CTAssetsPickerController/CTAssetsPickerController.h
@@ -112,6 +112,14 @@
 @property (nonatomic, assign) BOOL showsNumberOfAssets;
 
 /**
+ *  Title for Done button.
+ *
+ *  Default title for right button in the navigation bar.
+ *  Pass nil to reset to default value ("Done" in current localization).
+ */
+@property (nonatomic, copy) NSString* doneButtonTitle;
+
+/**
  *  Determines whether or not the done button is always enabled.
  *
  *  The done button is enabled only when assets are selected. To enable the done button even without assets selected,

--- a/CTAssetsPickerController/CTAssetsPickerController.m
+++ b/CTAssetsPickerController/CTAssetsPickerController.m
@@ -75,6 +75,7 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
         _showsCancelButton                  = YES;
         _showsEmptyAlbums                   = YES;
         _showsNumberOfAssets                = YES;
+		_doneButtonTitle                    = [[self class] defaultDoneButtonTitle];
         _alwaysEnableDoneButton             = NO;
         _defaultAssetCollection             = PHAssetCollectionSubtypeAny;
         
@@ -374,7 +375,7 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
 {
     if ([keyPath isEqual:@"selectedAssets"])
     {
-        [self toggleDoneButton];
+        [self updateDoneButton];
         [self postSelectedAssetsDidChangeNotification:[object valueForKey:keyPath]];
     }
 }
@@ -382,7 +383,7 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
 
 #pragma mark - Toggle button
 
-- (void)toggleDoneButton
+- (void)updateDoneButton
 {
     UIViewController *vc = self.childSplitViewController.viewControllers.firstObject;
     
@@ -391,7 +392,12 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
         BOOL enabled = (self.alwaysEnableDoneButton) ? YES : (self.selectedAssets.count > 0);
         
         for (UIViewController *viewController in ((UINavigationController *)vc).viewControllers)
-            viewController.navigationItem.rightBarButtonItem.enabled = enabled;
+		{
+			if ([viewController respondsToSelector:@selector(updateButton:)])
+				[(id)viewController updateButton:self.selectedAssets];
+			else
+				viewController.navigationItem.rightBarButtonItem.enabled = enabled;
+		}
     }
 }
 
@@ -547,6 +553,21 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
     }
 }
 
+#pragma mark - Done button title
+
++ (NSString*)defaultDoneButtonTitle
+{
+	return CTAssetsPickerLocalizedString(@"Done", nil);
+}
+
+- (void)setDoneButtonTitle:(NSString *)newValue
+{
+	if (!newValue.length)
+		newValue = [[self class] defaultDoneButtonTitle];
+	
+	_doneButtonTitle = [newValue copy];
+	[self updateDoneButton];
+}
 
 #pragma mark - Actions
 

--- a/CTAssetsPickerDemo.xcodeproj/project.pbxproj
+++ b/CTAssetsPickerDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		363F8D0A685BF86C60D06D49 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1B2FBB7FD634FB543BB7BB6 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		3CE9F5681B9C63D900491639 /* CTCustomDoneButtonViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9F5671B9C63D900491639 /* CTCustomDoneButtonViewController.m */; };
 		AD0786D91B428313003C8863 /* CTBasicViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AD0786D81B428313003C8863 /* CTBasicViewController.m */; };
 		AD0786DF1B42864F003C8863 /* CTSelectedAssetsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AD0786DE1B42864F003C8863 /* CTSelectedAssetsViewController.m */; };
 		AD0786E21B428A73003C8863 /* CTDefaultAlbumViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AD0786E11B428A73003C8863 /* CTDefaultAlbumViewController.m */; };
@@ -31,6 +32,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3CE9F5661B9C63D900491639 /* CTCustomDoneButtonViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTCustomDoneButtonViewController.h; sourceTree = "<group>"; };
+		3CE9F5671B9C63D900491639 /* CTCustomDoneButtonViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTCustomDoneButtonViewController.m; sourceTree = "<group>"; };
 		408BD0916F5C7C71C93D0E93 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		A741BBA21B5F7A8C00ED3D7B /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		A741BBA31B5F7A8C00ED3D7B /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/CTAssetsPicker.strings; sourceTree = "<group>"; };
@@ -216,6 +219,8 @@
 				ADFE23871B46602400E44353 /* CTProgrammaticViewController.m */,
 				ADFE23891B46868100E44353 /* CTApperanceViewController.h */,
 				ADFE238A1B46868100E44353 /* CTApperanceViewController.m */,
+				3CE9F5661B9C63D900491639 /* CTCustomDoneButtonViewController.h */,
+				3CE9F5671B9C63D900491639 /* CTCustomDoneButtonViewController.m */,
 				ADFC004A1B54FF740024CBB9 /* CTLayoutViewController.h */,
 				ADFC004B1B54FF740024CBB9 /* CTLayoutViewController.m */,
 			);
@@ -506,6 +511,7 @@
 				ADA073041B45118F009FB7C7 /* CTMaxSelectionViewController.m in Sources */,
 				AD4B06CB1B44CD5A00D99C5A /* CTSortedAssetsViewController.m in Sources */,
 				ADA073101B462C98009FB7C7 /* CTLastWeekViewController.m in Sources */,
+				3CE9F5681B9C63D900491639 /* CTCustomDoneButtonViewController.m in Sources */,
 				AD4B06C81B428EEF00D99C5A /* CTiCloudAlbumsViewController.m in Sources */,
 				AD0786E21B428A73003C8863 /* CTDefaultAlbumViewController.m in Sources */,
 				AD0786D91B428313003C8863 /* CTBasicViewController.m in Sources */,

--- a/CTAssetsPickerDemo/CTMasterViewController.m
+++ b/CTAssetsPickerDemo/CTMasterViewController.m
@@ -43,6 +43,7 @@
 #import "CTProgrammaticViewController.h"
 
 #import "CTApperanceViewController.h"
+#import "CTCustomDoneButtonViewController.h"
 
 #import "CTLayoutViewController.h"
 
@@ -86,7 +87,7 @@
             break;
             
         case 4:
-            return 1;
+            return 2;
             break;
             
         case 5:
@@ -193,10 +194,12 @@
     
     if (section == 4)
     {
-        if (row == 0)
-            title = @"UI Customisation";
+		if (row == 0)
+			title = @"UI Customisation";
+		if (row == 1)
+			title = @"Done Button Customisation";
     }
-    
+	
     if (section == 5)
     {
         if (row == 0)
@@ -265,8 +268,10 @@
     
     if (section == 4)
     {
-        if (row == 0)
-            vc = (UIViewController *)[CTApperanceViewController new];
+		if (row == 0)
+			vc = (UIViewController *)[CTApperanceViewController new];
+		if (row == 1)
+			vc = (UIViewController *)[CTCustomDoneButtonViewController new];
     }
 
     if (section == 5)

--- a/CTAssetsPickerDemo/Examples/CTCustomDoneButtonViewController.h
+++ b/CTAssetsPickerDemo/Examples/CTCustomDoneButtonViewController.h
@@ -1,0 +1,31 @@
+/*
+ 
+ MIT License (MIT)
+ 
+ Copyright (c) 2013 Clement CN Tsang
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ 
+ */
+
+#import "CTBasicViewController.h"
+
+@interface CTCustomDoneButtonViewController : CTBasicViewController
+
+@end

--- a/CTAssetsPickerDemo/Examples/CTCustomDoneButtonViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTCustomDoneButtonViewController.m
@@ -1,0 +1,84 @@
+/*
+ 
+ MIT License (MIT)
+ 
+ Copyright (c) 2013 Clement CN Tsang
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ 
+ */
+
+#import "CTCustomDoneButtonViewController.h"
+
+@interface CTCustomDoneButtonViewController ()
+
+@end
+
+@implementation CTCustomDoneButtonViewController
+
+- (void)pickAssets:(id)sender
+{
+	[PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status){
+		dispatch_async(dispatch_get_main_queue(), ^{
+			
+			// init picker
+			CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+			
+			// set delegate
+			picker.delegate = self;
+			
+			// to present picker as a form sheet in iPad
+			if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+				picker.modalPresentationStyle = UIModalPresentationFormSheet;
+			
+			// present picker
+			[self presentViewController:picker animated:YES completion:nil];
+			
+		});
+	}];
+}
+
+- (void)updateDoneButtonTitleInAssetsPicker:(CTAssetsPickerController *)picker
+{
+	NSUInteger numberOfSelectedAssets = picker.selectedAssets.count;
+	
+	// Alernate button title to much longer, much shorter, default
+	if (numberOfSelectedAssets % 3 == 1) {
+		// Very short title
+		picker.doneButtonTitle = @"OK";
+	} else if (numberOfSelectedAssets % 3 == 2) {
+		// Very long title
+		picker.doneButtonTitle = [NSString stringWithFormat:@"Choose %@ Items", @(numberOfSelectedAssets)];
+	} else {
+		// Default title
+		picker.doneButtonTitle = nil;
+	}
+}
+
+- (void)assetsPickerController:(CTAssetsPickerController *)picker didSelectAsset:(PHAsset *)asset
+{
+	[self updateDoneButtonTitleInAssetsPicker:picker];
+}
+
+- (void)assetsPickerController:(CTAssetsPickerController *)picker didDeselectAsset:(PHAsset *)asset
+{
+	[self updateDoneButtonTitleInAssetsPicker:picker];
+}
+
+@end

--- a/CTAssetsPickerDemo/Examples/CTUITweaksViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTUITweaksViewController.m
@@ -46,9 +46,12 @@
             // hide cancel button;
             picker.showsCancelButton = NO;
             
-            // make done button enable even without selection
-            picker.alwaysEnableDoneButton = YES;
-            
+			// make done button enable even without selection
+			picker.alwaysEnableDoneButton = YES;
+			
+			// change done button title to custom value
+			picker.doneButtonTitle = @"Pick";
+			
             // do not show number of assets in album list
             picker.showsNumberOfAssets = NO;
             


### PR DESCRIPTION
Added ability to customize title for Done button.
Sample usage in CTUITweaksViewController, and CTCustomDoneButtonViewController (new sample controller, added to Appearance section).

This adds public interface (doneButtonTitle property), but in backwards-compatible way, so the version for CocoaPod might need to be incremented to 3.1.0. That is, if you choose to merge it - but please do. The obvious use case is, e.g. we use the picker to choose the images to be uploaded to a server, so we want this button to say "Upload" rather than "Done".