### PR TITLE
Use estimatedAssetCount when updating collections

### DIFF
--- a/CTAssetsPickerController/CTAssetCollectionViewController.m
+++ b/CTAssetsPickerController/CTAssetCollectionViewController.m
@@ -201,7 +201,7 @@
     {
         for (PHAssetCollection *assetCollection in fetchResult)
         {
-            NSInteger count = [assetCollection ctassetPikcerCountOfAssetsFetchedWithOptions:self.picker.assetsFetchOptions];
+            NSInteger count = (assetCollection.estimatedAssetCount) ? assetCollection.estimatedAssetCount : 0;
             
             if (self.picker.showsEmptyAlbums || count > 0)
                 [assetCollections addObject:assetCollection];


### PR DESCRIPTION
I noticed loading the picker becomes extremely slow (a few seconds on an iPhone 6, and as long as 10 - 15 seconds on an iPhone 4S) when you have a few thousand photos in your library. The bottleneck appears to be in calculating the number of items in a given collection – currently it requires fetching full PHAsset objects, and I think using estimatedAssetCount on the PHAssetCollection object would be a more efficient option. After implementing, I noticed the load time on the 4S comes down to 1 - 2 seconds.

![screen shot 2015-09-17 at 9 06 04 pm](https://cloud.githubusercontent.com/assets/371957/9933932/f975dee2-5d80-11e5-959b-e25bed1c0742.png)
