### PR TITLE
Add support for App Extension

### DIFF
--- a/CTAssetsPickerController/CTAssetScrollView.m
+++ b/CTAssetsPickerController/CTAssetScrollView.m
@@ -210,7 +210,9 @@ NSString * const CTAssetScrollViewPlayerWillPauseNotification = @"CTAssetScrollV
 
 - (void)setProgress:(CGFloat)progress
 {
+#if !defined(CT_APP_EXTENSIONS)
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:(progress < 1)];
+#endif
     [self.progressView setProgress:progress animated:(progress < 1)];
     [self.progressView setHidden:(progress == 1)];
 }


### PR DESCRIPTION
If you will define preprocessor macro, then this code will be skipped and app extension allow to build framework. Similar concept had AFNetworking few commits ago, but right now i see that they are marking method to be NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions."), but in this case it is not possible. Just check AF_APP_EXTENSIONS macro in google