### PR TITLE
fix crash during device rotation

### DIFF
--- a/CTAssetsPickerController/CTAssetsGridViewController.m
+++ b/CTAssetsPickerController/CTAssetsGridViewController.m
@@ -210,6 +210,13 @@ NSString * const CTAssetsGridViewFooterIdentifier = @"CTAssetsGridViewFooterIden
     CGSize contentSize = self.view.bounds.size;
     UICollectionViewLayout *layout;
 
+    NSArray *attributes = [self.collectionView.collectionViewLayout layoutAttributesForElementsInRect:self.collectionView.bounds];
+    UICollectionViewLayoutAttributes *attr = (UICollectionViewLayoutAttributes*)attributes.firstObject;
+    // new content size should be at least of first item size, else ignoring
+    if (contentSize.width < attr.size.width || contentSize.height < attr.size.height) {
+        return;
+    }
+
     if ([self.picker.delegate respondsToSelector:@selector(assetsPickerController:collectionViewLayoutForContentSize:traitCollection:)]) {
         layout = [self.picker.delegate assetsPickerController:self.picker collectionViewLayoutForContentSize:contentSize traitCollection:trait];
     } else {


### PR DESCRIPTION
In some rare cases, UICollectionView may throw an exception while items reloading (see http://stackoverflow.com/questions/13929518/ for example).
The crash occurs when items size does not fit into CollectionView’s contentSize + offsets or having negative width/height. One possible reason of it is the case when (during a rotation) view.bound.size returns a very small size.
This fix trying to catch that case and ignore all the rest code.

Couldn't reproduce that behavior on a clean project, but that crash occurs pretty frequently on 6+ devices in one of my production projects. It looks like this:
![ctassetsgridviewcontroller m edited 2016-03-25 01-43-46](https://cloud.githubusercontent.com/assets/2203199/14033399/6f18990e-f233-11e5-8a43-78bc2c4b0c62.jpg)
