### PR TITLE
Support Custom Fetch Result

### DIFF
--- a/CTAssetsPickerController/CTAssetCollectionViewCell.h
+++ b/CTAssetsPickerController/CTAssetCollectionViewCell.h
@@ -48,7 +48,7 @@
 @property (nonatomic, weak, nullable) UIColor *selectedBackgroundColor UI_APPEARANCE_SELECTOR;
 
 
-- (instancetype)initWithThumbnailSize:(CGSize)size reuseIdentifier:(nullable NSString *)reuseIdentifier;
+- (nonnull instancetype)initWithThumbnailSize:(CGSize)size reuseIdentifier:(nullable NSString *)reuseIdentifier;
 - (void)bind:(nonnull PHAssetCollection *)collection count:(NSUInteger)count;
 
 @end

--- a/CTAssetsPickerController/CTAssetThumbnailStacks.h
+++ b/CTAssetsPickerController/CTAssetThumbnailStacks.h
@@ -30,7 +30,7 @@
 @interface CTAssetThumbnailStacks : UIView
 
 @property (nonatomic, assign) CGSize thumbnailSize;
-@property (nonatomic, copy, readonly) NSArray<CTAssetThumbnailView*> *thumbnailViews;
+@property (nonatomic, copy, readonly, nonnull) NSArray<CTAssetThumbnailView*> *thumbnailViews;
 @property (nonatomic, assign, readonly) UIEdgeInsets edgeInsets;
 
 - (nonnull CTAssetThumbnailView *)thumbnailAtIndex:(NSUInteger)index;

--- a/CTAssetsPickerController/CTAssetsGridViewController.h
+++ b/CTAssetsPickerController/CTAssetsGridViewController.h
@@ -42,9 +42,9 @@
 
 @interface CTAssetsGridViewController : UICollectionViewController
 
-@property (nonatomic, weak) id<CTAssetsGridViewControllerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<CTAssetsGridViewControllerDelegate> delegate;
 @property (nonatomic, strong, nonnull) PHAssetCollection *assetCollection;
+@property (nonatomic, strong, nullable) PHFetchResult<PHAsset*> *pickFromFetch;
 
 @end
-
 

--- a/CTAssetsPickerController/CTAssetsGridViewController.m
+++ b/CTAssetsPickerController/CTAssetsGridViewController.m
@@ -53,7 +53,7 @@ NSString * const CTAssetsGridViewFooterIdentifier = @"CTAssetsGridViewFooterIden
 <PHPhotoLibraryChangeObserver>
 
 @property (nonatomic, weak) CTAssetsPickerController *picker;
-@property (nonatomic, strong) PHFetchResult *fetchResult;
+@property (nonatomic, strong) PHFetchResult<PHAsset*> *fetchResult;
 @property (nonatomic, strong) PHCachingImageManager *imageManager;
 
 @property (nonatomic, assign) CGRect previousPreheatRect;
@@ -188,15 +188,28 @@ NSString * const CTAssetsGridViewFooterIdentifier = @"CTAssetsGridViewFooterIden
                                         target:self.picker
                                         action:@selector(finishPickingAssets:)];
     }
+    
+    if (self.pickFromFetch && self.picker.showsCancelButton) {
+        self.navigationItem.leftBarButtonItem =
+        [[UIBarButtonItem alloc] initWithTitle:CTAssetsPickerLocalizedString(@"Cancel", nil)
+                                         style:UIBarButtonItemStylePlain
+                                        target:self.picker
+                                        action:@selector(dismiss:)];
+    }
 }
 
 - (void)setupAssets
 {
-    PHFetchResult *fetchResult =
-    [PHAsset fetchAssetsInAssetCollection:self.assetCollection
-                                  options:self.picker.assetsFetchOptions];
+    if (_pickFromFetch) {
+        self.fetchResult = _pickFromFetch;
+    } else {
+        PHFetchResult *fetchResult =
+        [PHAsset fetchAssetsInAssetCollection:self.assetCollection
+                                      options:self.picker.assetsFetchOptions];
+        
+        self.fetchResult = fetchResult;
+    }
     
-    self.fetchResult = fetchResult;
     [self reloadData];
 }
 

--- a/CTAssetsPickerController/CTAssetsPickerController.h
+++ b/CTAssetsPickerController/CTAssetsPickerController.h
@@ -142,6 +142,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly, strong) UISplitViewController *childSplitViewController;
 
+/**
+ *  Displays the picker to pick between the fetch result. Must be a PHAsset type fetch.
+ *  
+ *  It will not display the list of albums, but only the assets in the specified fetch result.
+ */
+@property (strong, nonatomic) PHFetchResult<PHAsset*> *pickFromFetch;
 
 /**
  *  @name Managing Selections

--- a/CTAssetsPickerController/CTAssetsPickerController.m
+++ b/CTAssetsPickerController/CTAssetsPickerController.m
@@ -250,6 +250,13 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
 {
     CTAssetCollectionViewController *vc = [CTAssetCollectionViewController new];
     CTAssetsNavigationController *master = [[CTAssetsNavigationController alloc] initWithRootViewController:vc];
+    
+    if (self.pickFromFetch) {
+        CTAssetsGridViewController *grid = [CTAssetsGridViewController new];
+        grid.pickFromFetch = self.pickFromFetch;
+        master.viewControllers = @[grid];
+    }
+    
     UINavigationController *detail = [self emptyNavigationController];
     UISplitViewController *svc  = [UISplitViewController new];
     

--- a/CTAssetsPickerDemo.xcodeproj/project.pbxproj
+++ b/CTAssetsPickerDemo.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		ADFC004C1B54FF740024CBB9 /* CTLayoutViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ADFC004B1B54FF740024CBB9 /* CTLayoutViewController.m */; };
 		ADFE23881B46602400E44353 /* CTProgrammaticViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ADFE23871B46602400E44353 /* CTProgrammaticViewController.m */; };
 		ADFE238B1B46868100E44353 /* CTApperanceViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ADFE238A1B46868100E44353 /* CTApperanceViewController.m */; };
+		D57946551CB452DE008C14D4 /* CTCustomFetchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D57946541CB452DE008C14D4 /* CTCustomFetchViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -185,6 +186,8 @@
 		ADFE23871B46602400E44353 /* CTProgrammaticViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTProgrammaticViewController.m; sourceTree = "<group>"; };
 		ADFE23891B46868100E44353 /* CTApperanceViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTApperanceViewController.h; sourceTree = "<group>"; };
 		ADFE238A1B46868100E44353 /* CTApperanceViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTApperanceViewController.m; sourceTree = "<group>"; };
+		D57946531CB452DE008C14D4 /* CTCustomFetchViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTCustomFetchViewController.h; sourceTree = "<group>"; };
+		D57946541CB452DE008C14D4 /* CTCustomFetchViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTCustomFetchViewController.m; sourceTree = "<group>"; };
 		F1B2FBB7FD634FB543BB7BB6 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD69CDFBA7D07D903CCC8B80 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -225,6 +228,8 @@
 				AD18AFD61BCC9BA9008B507D /* CTSelectionOrderViewController.m */,
 				ADA0730B1B4625AA009FB7C7 /* CTUITweaksViewController.h */,
 				ADA0730C1B4625AA009FB7C7 /* CTUITweaksViewController.m */,
+				D57946531CB452DE008C14D4 /* CTCustomFetchViewController.h */,
+				D57946541CB452DE008C14D4 /* CTCustomFetchViewController.m */,
 				AD4B06C91B44CD5A00D99C5A /* CTSortedAssetsViewController.h */,
 				AD4B06CA1B44CD5A00D99C5A /* CTSortedAssetsViewController.m */,
 				ADA073051B4515AF009FB7C7 /* CTPhotosViewController.h */,
@@ -423,7 +428,6 @@
 				TargetAttributes = {
 					ADD965C51AAD4C49002A26A2 = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = VE5FET45CD;
 					};
 				};
 			};
@@ -552,6 +556,7 @@
 				AD18AFD71BCC9BA9008B507D /* CTSelectionOrderViewController.m in Sources */,
 				ADFE238B1B46868100E44353 /* CTApperanceViewController.m in Sources */,
 				ADE2713C1ACBA6BA0090EFB1 /* NSIndexSet+CTAssetsPickerController.m in Sources */,
+				D57946551CB452DE008C14D4 /* CTCustomFetchViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CTAssetsPickerDemo/CTMasterViewController.m
+++ b/CTAssetsPickerDemo/CTMasterViewController.m
@@ -33,6 +33,7 @@
 #import "CTDefaultAlbumViewController.h"
 #import "CTSelectionOrderViewController.h"
 #import "CTUITweaksViewController.h"
+#import "CTCustomFetchViewController.h"
 
 #import "CTSortedAssetsViewController.h"
 
@@ -71,7 +72,7 @@
 {
     switch (section) {
         case 0:
-            return 6;
+            return 7;
             break;
 
         case 1:
@@ -166,6 +167,9 @@
         
         if (row == 5)
             title = @"UI tweaks";
+        
+        if (row == 6)
+            title = @"Custom Fetch";
     }
     
     if (section == 1)
@@ -241,6 +245,8 @@
         
         if (row == 5)
             vc = (UIViewController *)[CTUITweaksViewController new];
+        if (row == 6)
+            vc = (UIViewController *)[CTCustomFetchViewController new];
     }
     
     if (section == 1)

--- a/CTAssetsPickerDemo/Examples/CTCustomFetchViewController.h
+++ b/CTAssetsPickerDemo/Examples/CTCustomFetchViewController.h
@@ -1,0 +1,13 @@
+//
+//  CTCustomFetchViewController.h
+//  CTAssetsPickerDemo
+//
+//  Created by Felix Dumit on 4/5/16.
+//  Copyright © 2016 Clement T. All rights reserved.
+//
+
+#import "CTBasicViewController.h"
+
+@interface CTCustomFetchViewController : CTBasicViewController
+
+@end

--- a/CTAssetsPickerDemo/Examples/CTCustomFetchViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTCustomFetchViewController.m
@@ -1,0 +1,36 @@
+//
+//  CTCustomFetchViewController.m
+//  CTAssetsPickerDemo
+//
+//  Created by Felix Dumit on 4/5/16.
+//  Copyright © 2016 Clement T. All rights reserved.
+//
+
+#import "CTCustomFetchViewController.h"
+
+@implementation CTCustomFetchViewController
+
+- (void)pickAssets:(id)sender {
+    [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // init picker
+            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            
+            // set delegate
+            picker.delegate = self;
+            
+            // set custom fetch
+            picker.pickFromFetch = [PHAsset fetchAssetsWithOptions:nil];
+            
+            // to present picker as a form sheet in iPad
+            if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) picker.modalPresentationStyle = UIModalPresentationFormSheet;
+            
+            // present picker
+            [self             presentViewController:picker
+                                           animated:YES
+                                         completion:nil];
+        });
+    }];
+}
+
+@end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   CTAssetsPickerController:
-    :path: .
+    :path: "."
 
 SPEC CHECKSUMS:
   CTAssetsPickerController: b1d1d50ab87cf6b8b13531de5f4530482e7e53ed


### PR DESCRIPTION
I had a scenario where I wanted to use the picker to select the assets among an already established `PHFetchResult`, without the need to show all the albums.

Now you can set the `pickFromFetch` property of the picker which will enable this option.

example:

``` objc
CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
 // set delegate
picker.delegate = self;
// set custom fetch
picker.pickFromFetch = [PHAsset fetchAssetsWithOptions:nil];
```
